### PR TITLE
📦 new: add floating tags input and update dependencies for build flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ All flow types use **commit SHA** (first 7 characters) for tagging, ensuring tra
 
 > **Note:** The `{sha}` in each tag represents the **HEAD commit SHA** of the PR or push event, not the PR number. This ensures every build can be traced to its exact source code.
 
+> **Tip:** Enable `floating-tags: true` to also push a mutable `dev`, `pr`, `patch`, `staging`, or `wip` tag that always points to the latest build for that flow type — great for `docker-compose.yml` or Kubernetes manifests that should follow the tip of a branch without requiring manual SHA updates.
+
 ---
 
 ## 🏷️ Tagging Strategy
@@ -155,6 +157,29 @@ myorg/myapp:staging-ghi9012
 
 # With custom prefix/suffix
 myorg/myapp:v1-pr-abc1234-alpine
+
+# With floating-tags: true — also pushes a mutable floating tag
+myorg/myapp:dev          # always points to the latest dev build
+myorg/myapp:dev-def5678  # still pushed for reproducibility
+```
+
+### Floating Tags
+
+Enable `floating-tags: true` to push an additional mutable tag (e.g., `dev`, `pr`, `patch`, `staging`, `wip`) alongside the SHA-pinned tag on every non-release build. The floating tag always points to the most recent build for that flow type, while the SHA-pinned tag remains for reproducibility.
+
+```yaml
+- uses: wgtechlabs/container-build-flow-action@v1
+  with:
+    floating-tags: true   # push both dev-abc1234 AND dev
+```
+
+This is especially useful in `docker-compose.yml` or Kubernetes manifests where you want to follow the tip of a branch:
+
+```yaml
+# docker-compose.yml — always use the latest dev build
+services:
+  app:
+    image: myorg/myapp:dev
 ```
 
 ### Workflow Integration
@@ -615,6 +640,7 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 | `image-name` | Container image name | No | Repository name |
 | `tag-prefix` | Prefix for image tags | No | `''` |
 | `tag-suffix` | Suffix for image tags | No | `''` |
+| `floating-tags` | Push a mutable floating tag (e.g., `dev`, `pr`) alongside the SHA-pinned tag for non-release flows | No | `false` |
 
 ### PR Comments
 

--- a/action.yml
+++ b/action.yml
@@ -249,6 +249,12 @@ inputs:
     required: false
     default: 'true'
 
+  # Floating Tags
+  floating-tags:
+    description: 'Push a mutable floating tag (e.g., dev, pr, patch, staging, wip) for each non-release build in addition to the SHA-pinned tag. Useful for always pulling the latest build of a given flow type without updating the SHA manually.'
+    required: false
+    default: 'false'
+
 outputs:
   image-tags:
     description: 'Complete list of applied image tags'
@@ -385,6 +391,7 @@ runs:
         RELEASE_TAG: ${{ github.event.release.tag_name }}
         RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         RELEASE_TAG_PATTERN: ${{ inputs.release-tag-pattern }}
+        FLOATING_TAGS: ${{ inputs.floating-tags }}
 
     - name: Resolve Build Platforms
       id: platforms

--- a/action.yml
+++ b/action.yml
@@ -416,7 +416,7 @@ runs:
     
     - name: Run Trivy Filesystem Scan (Source Code)
       if: steps.commit-gate.outputs.should-build != 'false' && inputs.pre-build-scan-enabled == 'true' && inputs.scan-source-code == 'true' && steps.detect.outputs.build-flow-type != 'skip'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'fs'
@@ -431,7 +431,7 @@ runs:
     
     - name: Upload Source Code Scan to GitHub Security
       if: steps.commit-gate.outputs.should-build != 'false' && inputs.pre-build-scan-enabled == 'true' && inputs.scan-source-code == 'true' && inputs.upload-sarif == 'true' && steps.detect.outputs.build-flow-type != 'skip'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'fs'
@@ -454,7 +454,7 @@ runs:
     
     - name: Run Trivy Config Scan (Dockerfile)
       if: steps.commit-gate.outputs.should-build != 'false' && inputs.pre-build-scan-enabled == 'true' && inputs.scan-dockerfile == 'true' && steps.detect.outputs.build-flow-type != 'skip'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'config'
@@ -466,7 +466,7 @@ runs:
     
     - name: Upload Dockerfile Scan to GitHub Security
       if: steps.commit-gate.outputs.should-build != 'false' && inputs.pre-build-scan-enabled == 'true' && inputs.scan-dockerfile == 'true' && inputs.upload-sarif == 'true' && steps.detect.outputs.build-flow-type != 'skip'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'config'
@@ -558,7 +558,7 @@ runs:
     
     - name: Scan Baseline Image (for comparison)
       if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.enable-image-comparison == 'true' && inputs.comparison-baseline-image != '' && steps.detect.outputs.build-flow-type != 'skip'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'image'
@@ -571,7 +571,7 @@ runs:
     
     - name: Scan Container Image
       if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && steps.detect.outputs.build-flow-type != 'skip'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'image'
@@ -624,7 +624,7 @@ runs:
     
     - name: Upload Container Image Scan to GitHub Security
       if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.upload-sarif == 'true' && steps.detect.outputs.build-flow-type != 'skip'
-      uses: aquasecurity/trivy-action@0.35.0
+      uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'image'

--- a/action.yml
+++ b/action.yml
@@ -649,7 +649,7 @@ runs:
     
     - name: Comment on Pull Request
       if: steps.commit-gate.outputs.should-build != 'false' && inputs.pr-comment-enabled == 'true' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         github-token: ${{ inputs.ghcr-token || github.token }}
         script: |

--- a/scripts/detect-build-flow.sh
+++ b/scripts/detect-build-flow.sh
@@ -22,7 +22,8 @@
 # Outputs (via GitHub Actions):
 #   - build-flow-type  : The detected flow type
 #   - tags             : Generated container tag (primary)
-#   - extra-tags       : Additional tags for release flows (multi-line type=raw)
+#   - extra-tags       : Additional tags (multi-line type=raw): semver/channel/latest tags
+#                        for release flows, and optional floating tags for non-release flows
 #   - short-sha        : Short commit SHA
 #   - release-version  : Clean version string (release only)
 #   - dockerhub-image  : Docker Hub image name

--- a/scripts/detect-build-flow.sh
+++ b/scripts/detect-build-flow.sh
@@ -54,6 +54,7 @@ DEV_BRANCH="${DEV_BRANCH:-dev}"
 TAG_PREFIX="${TAG_PREFIX:-}"
 TAG_SUFFIX="${TAG_SUFFIX:-}"
 IMAGE_NAME="${IMAGE_NAME:-}"
+FLOATING_TAGS="${FLOATING_TAGS:-false}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -327,6 +328,12 @@ type=raw,value=${TAG_PREFIX}latest${TAG_SUFFIX}"
         full_tag="${TAG_PREFIX}${base_tag}${TAG_SUFFIX}"
         log_debug "  Base tag: ${base_tag}"
         log_debug "  Full tag: ${full_tag}"
+
+        # Floating tag: mutable tag pointing to the latest build of this flow type
+        if [ "$FLOATING_TAGS" = "true" ]; then
+            extra_tags="type=raw,value=${TAG_PREFIX}${flow_type}${TAG_SUFFIX}"
+            log_debug "  Floating tag: ${TAG_PREFIX}${flow_type}${TAG_SUFFIX}"
+        fi
     fi
 
     # =============================================================================


### PR DESCRIPTION
This pull request introduces support for "floating tags" in the container build flow, allowing users to push a mutable tag (such as `dev`, `pr`, or `staging`) that always points to the latest build for a given flow type, in addition to the existing SHA-pinned tags. This is particularly useful for workflows and deployments that should always track the latest build without manual updates. The documentation and configuration files have been updated to describe and enable this new feature. Additionally, several dependencies have been updated to their latest versions.

**Floating Tag Feature:**

* Added a new `floating-tags` input in `action.yml` to optionally push a mutable floating tag (e.g., `dev`, `pr`) alongside the SHA-pinned tag for non-release builds. This is configurable and defaults to `false`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R252-R257) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R394) [[3]](diffhunk://#diff-b07779b59b71e0fa73db81f737833b41313721989c57ae7494e2c926036f418cR57)
* Updated the tagging logic in `scripts/detect-build-flow.sh` to support the creation and logging of floating tags when enabled.

**Documentation Updates:**

* Expanded the `README.md` with an explanation and usage examples for floating tags, including configuration guidance and practical scenarios (e.g., using `docker-compose.yml` or Kubernetes manifests). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R131-R132) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R160-R182)
* Added `floating-tags` to the documented list of action inputs and updated the options table for clarity.

**Dependency Updates:**

* Upgraded `aquasecurity/trivy-action` from version `0.35.0` to `v0.36.0` for all security scanning steps in `action.yml`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L412-R419) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L427-R434) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L450-R457) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L462-R469) [[5]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L554-R561) [[6]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L567-R574) [[7]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L620-R627)
* Updated `actions/github-script` from version `v8` to `v9` for improved compatibility and features.