### PR TITLE
🔧 update: fix bot-detection false skips on human-authored PRs (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,8 +685,19 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `bot-detection` | Auto-detect bot actors and skip the build | No | `true` |
+| `bot-detection-mode` | Controls which identity is evaluated for bot detection (`smart`, `actor`, `pr-author`) | No | `smart` |
+
+#### Bot Detection Mode
+
+| Mode | Behavior |
+|------|----------|
+| `smart` | **Recommended default.** Uses PR author for `pull_request`/`pull_request_target` events, falls back to `github.actor` for all other events (push, release, etc.) |
+| `actor` | Always evaluates `github.actor` — preserves the original legacy behavior |
+| `pr-author` | Always evaluates the PR author when available, falls back to `github.actor` if no PR author exists |
 
 > **Tip:** When enabled, bot actors like `dependabot[bot]` and `renovate[bot]` are automatically detected. The build is gracefully skipped with a clear reason, preventing CI failures from missing secrets on bot-generated PRs. The job still shows a green check, making it safe to use as a required status check.
+
+> **Why `smart` mode?** With `actor` mode, a human-authored PR can be falsely skipped when a bot (e.g., Renovate) triggers a `synchronize` event — even though the PR author is human. `smart` mode prevents this false positive by evaluating the PR author instead of the triggering actor on PR events.
 
 ---
 
@@ -700,6 +711,8 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 | `build-flow-type` | Detected flow type (`pr`, `dev`, `patch`, `staging`, `wip`, `release`, `skip`) |
 | `short-sha` | Short commit SHA used in tags |
 | `bot-detected` | Whether a bot actor was detected (`true`/`false`) |
+| `bot-evaluation-subject` | Which identity was evaluated for bot detection (`actor` or `pr-author`) |
+| `bot-evaluation-value` | The actual login value evaluated for bot detection |
 | `build-skip-reason` | Reason the build was skipped (bot or commit convention) |
 | `vulnerability-scan-completed` | Whether vulnerability scanning completed successfully |
 | `total-vulnerabilities` | Total number of vulnerabilities found |

--- a/README.md
+++ b/README.md
@@ -711,8 +711,8 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 | `build-flow-type` | Detected flow type (`pr`, `dev`, `patch`, `staging`, `wip`, `release`, `skip`) |
 | `short-sha` | Short commit SHA used in tags |
 | `bot-detected` | Whether a bot actor was detected (`true`/`false`) |
-| `bot-evaluation-subject` | Which identity was evaluated for bot detection (`actor` or `pr-author`) |
-| `bot-evaluation-value` | The actual login value evaluated for bot detection |
+| `bot-evaluation-subject` | Which identity was evaluated for bot detection (`actor`, `pr-author`, or `none` when detection is disabled) |
+| `bot-evaluation-value` | The actual login value evaluated for bot detection (empty when detection is disabled) |
 | `build-skip-reason` | Reason the build was skipped (bot or commit convention) |
 | `vulnerability-scan-completed` | Whether vulnerability scanning completed successfully |
 | `total-vulnerabilities` | Total number of vulnerabilities found |

--- a/action.yml
+++ b/action.yml
@@ -249,6 +249,11 @@ inputs:
     required: false
     default: 'true'
 
+  bot-detection-mode:
+    description: 'Controls which identity is evaluated for bot detection: smart (default, uses PR author for PR events), actor (always uses github.actor), or pr-author (always uses PR author when available). See README for details.'
+    required: false
+    default: 'smart'
+
   # Floating Tags
   floating-tags:
     description: 'Push a mutable floating tag (e.g., dev, pr, patch, staging, wip) for each non-release build in addition to the SHA-pinned tag. Useful for always pulling the latest build of a given flow type without updating the SHA manually.'
@@ -311,8 +316,16 @@ outputs:
     value: ${{ steps.commit-gate.outputs.commit-type }}
   
   bot-detected:
-    description: 'Whether a bot actor was detected (true/false). Only populated when bot-detection is enabled.'
+    description: 'Whether a bot was detected (true/false). Always set, even when bot-detection is disabled (returns false in that case).'
     value: ${{ steps.bot-gate.outputs.is-bot }}
+
+  bot-evaluation-subject:
+    description: 'The identity evaluated for bot detection (actor or pr-author).'
+    value: ${{ steps.bot-gate.outputs.bot-evaluation-subject }}
+
+  bot-evaluation-value:
+    description: 'The actual login value that was evaluated for bot detection (e.g., dependabot[bot] or warengonzaga).'
+    value: ${{ steps.bot-gate.outputs.bot-evaluation-value }}
 
   build-skip-reason:
     description: 'Reason the build was skipped (bot detection or commit convention gate). Empty if the build proceeded.'
@@ -321,26 +334,67 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Detect Bot Actor
+    - name: Bot Detection Gate
       id: bot-gate
       shell: bash
       run: |
         ACTOR="${{ github.actor }}"
+        PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+        EVENT_NAME="${{ github.event_name }}"
         BOT_DETECTION="${{ inputs.bot-detection }}"
+        BOT_DETECTION_MODE="${{ inputs.bot-detection-mode }}"
+
+        # Validate bot-detection-mode
+        case "$BOT_DETECTION_MODE" in
+          smart|actor|pr-author)
+            ;;
+          *)
+            echo "❌ Invalid bot-detection-mode value: '${BOT_DETECTION_MODE}'. Allowed values: smart, actor, pr-author."
+            exit 1
+            ;;
+        esac
 
         if [ "$BOT_DETECTION" != "true" ]; then
           echo "is-bot=false" >> "$GITHUB_OUTPUT"
+          echo "bot-evaluation-subject=actor" >> "$GITHUB_OUTPUT"
+          echo "bot-evaluation-value=${ACTOR}" >> "$GITHUB_OUTPUT"
           echo "ℹ️  Bot detection is disabled"
           exit 0
         fi
 
-        if [[ "$ACTOR" == *"[bot]"* ]]; then
+        # Determine which subject to evaluate based on mode and event type
+        SUBJECT="actor"
+        SUBJECT_VALUE="$ACTOR"
+
+        if [ "$BOT_DETECTION_MODE" = "smart" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ]; then
+            if [ -n "$PR_AUTHOR" ]; then
+              SUBJECT="pr-author"
+              SUBJECT_VALUE="$PR_AUTHOR"
+              echo "ℹ️  Smart mode: PR event detected — evaluating PR author '${SUBJECT_VALUE}' instead of actor '${ACTOR}'"
+            fi
+          fi
+        elif [ "$BOT_DETECTION_MODE" = "pr-author" ]; then
+          if [ -n "$PR_AUTHOR" ]; then
+            SUBJECT="pr-author"
+            SUBJECT_VALUE="$PR_AUTHOR"
+            echo "ℹ️  pr-author mode: evaluating PR author '${SUBJECT_VALUE}' instead of actor '${ACTOR}'"
+          else
+            echo "ℹ️  pr-author mode: no PR author available, falling back to actor '${ACTOR}'"
+          fi
+        fi
+        # actor mode: keep defaults (SUBJECT=actor, SUBJECT_VALUE=ACTOR)
+
+        echo "bot-evaluation-subject=${SUBJECT}" >> "$GITHUB_OUTPUT"
+        echo "bot-evaluation-value=${SUBJECT_VALUE}" >> "$GITHUB_OUTPUT"
+
+        if [[ "$SUBJECT_VALUE" == *"[bot]"* ]]; then
           echo "is-bot=true" >> "$GITHUB_OUTPUT"
-          echo "build-skip-reason=Bot actor: ${ACTOR}" >> "$GITHUB_OUTPUT"
-          echo "⚠️  Bot actor detected (${ACTOR}) — build will be skipped"
+          echo "build-skip-reason=Bot ${SUBJECT}: ${SUBJECT_VALUE}" >> "$GITHUB_OUTPUT"
+          echo "⚠️  Bot ${SUBJECT} detected (${SUBJECT_VALUE}) — build will be skipped"
         else
           echo "is-bot=false" >> "$GITHUB_OUTPUT"
-          echo "ℹ️  Actor '${ACTOR}' is not a bot"
+          echo "ℹ️  Evaluated ${SUBJECT} '${SUBJECT_VALUE}' — not a bot"
         fi
 
     - name: Resolve Commit SHA

--- a/action.yml
+++ b/action.yml
@@ -320,11 +320,11 @@ outputs:
     value: ${{ steps.bot-gate.outputs.is-bot }}
 
   bot-evaluation-subject:
-    description: 'The identity evaluated for bot detection (actor or pr-author).'
+    description: 'The identity evaluated for bot detection (actor, pr-author, or none when detection is disabled).'
     value: ${{ steps.bot-gate.outputs.bot-evaluation-subject }}
 
   bot-evaluation-value:
-    description: 'The actual login value that was evaluated for bot detection (e.g., dependabot[bot] or warengonzaga).'
+    description: 'The actual login value that was evaluated for bot detection (e.g., dependabot[bot] or warengonzaga). Empty when detection is disabled.'
     value: ${{ steps.bot-gate.outputs.bot-evaluation-value }}
 
   build-skip-reason:
@@ -344,7 +344,15 @@ runs:
         BOT_DETECTION="${{ inputs.bot-detection }}"
         BOT_DETECTION_MODE="${{ inputs.bot-detection-mode }}"
 
-        # Validate bot-detection-mode
+        if [ "$BOT_DETECTION" != "true" ]; then
+          echo "is-bot=false" >> "$GITHUB_OUTPUT"
+          echo "bot-evaluation-subject=none" >> "$GITHUB_OUTPUT"
+          echo "bot-evaluation-value=" >> "$GITHUB_OUTPUT"
+          echo "ℹ️  Bot detection is disabled"
+          exit 0
+        fi
+
+        # Validate bot-detection-mode (only when bot-detection is enabled)
         case "$BOT_DETECTION_MODE" in
           smart|actor|pr-author)
             ;;
@@ -353,14 +361,6 @@ runs:
             exit 1
             ;;
         esac
-
-        if [ "$BOT_DETECTION" != "true" ]; then
-          echo "is-bot=false" >> "$GITHUB_OUTPUT"
-          echo "bot-evaluation-subject=actor" >> "$GITHUB_OUTPUT"
-          echo "bot-evaluation-value=${ACTOR}" >> "$GITHUB_OUTPUT"
-          echo "ℹ️  Bot detection is disabled"
-          exit 0
-        fi
 
         # Determine which subject to evaluate based on mode and event type
         SUBJECT="actor"


### PR DESCRIPTION
This pull request introduces a new, configurable "bot detection mode" to improve the accuracy and transparency of bot detection in CI workflows. The main enhancement is the ability to control which user identity is checked for bot status, preventing false positives when bots trigger events on human-authored pull requests. Documentation and outputs have also been updated for clarity and traceability.

**Bot Detection Improvements**
- Added a new `bot-detection-mode` input to allow users to specify whether to evaluate the triggering actor, the PR author, or use a smart mode that adapts based on the event type. This helps avoid skipping builds on human-authored PRs triggered by bots. (`action.yml`, `README.md`) [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R252-R256) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R688-R701)
- Updated the bot detection logic in the composite action to select the correct subject for evaluation based on the chosen mode and event type, with clear logging and fallback behavior. (`action.yml`)

**Outputs and Documentation**
- Added two new outputs: `bot-evaluation-subject` (identifies which user was checked) and `bot-evaluation-value` (the login name that was evaluated), and documented them in both `action.yml` and `README.md`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L314-R397) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R714-R715)
- Improved output descriptions for `bot-detected` to clarify its behavior when detection is disabled.
- Expanded the README with a detailed table and rationale for each bot detection mode, including guidance on when to use each.

These changes provide more robust and transparent bot detection, reducing accidental build skips and making CI status checks more reliable.