### PR TITLE
🚀 release: publish planned container tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ All flow types use **commit SHA** (first 7 characters) for tagging, ensuring tra
 
 > **Tip:** Enable `floating-tags: true` to also push a mutable `dev`, `pr`, `patch`, `staging`, or `wip` tag that always points to the latest build for that flow type — great for `docker-compose.yml` or Kubernetes manifests that should follow the tip of a branch without requiring manual SHA updates.
 
+### Planned main-branch releases
+
+On a push to the configured `main-branch`, set `planned-version-tag` to publish release tags without changing the event from `push`. The full value must match `release-tag-pattern`; a matching `v1.2.3` produces `1.2.3`, `1.2`, `1`, and `latest` tags (with any configured prefix or suffix). An invalid value is skipped using the same behavior as an invalid release-event tag. Omit the input to retain the normal `staging-{sha}` main-branch build.
+
+```yaml
+- uses: wgtechlabs/container-build-flow-action@v1
+  with:
+    planned-version-tag: v1.2.3
+```
+
 ---
 
 ## 🏷️ Tagging Strategy
@@ -241,6 +251,10 @@ jobs:
     registry: ghcr
     ghcr-token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+### Independent registry publishing
+
+When `registry: both` is selected, Docker Hub and GHCR each receive an independent metadata, login, and build/push attempt. A failure in one does not prevent the other attempt. The action succeeds when either selected registry publishes successfully, and fails only after all selected publish attempts fail. Set `push-enabled: false` to build without publishing; this remains a successful no-push build.
 
 ### Custom Branch Names
 
@@ -620,6 +634,7 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 |-------|-------------|----------|---------|
 | `main-branch` | Name of main/production branch | No | `main` |
 | `dev-branch` | Name of development branch | No | `dev` |
+| `planned-version-tag` | Release tag to publish on a main-branch push; must match `release-tag-pattern` | No | `''` |
 
 ### Build Configuration
 
@@ -710,6 +725,9 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 | `build-digest` | SHA256 digest of built image |
 | `build-flow-type` | Detected flow type (`pr`, `dev`, `patch`, `staging`, `wip`, `release`, `skip`) |
 | `short-sha` | Short commit SHA used in tags |
+| `dockerhub-published` | Whether Docker Hub successfully received an image (`true`/`false`) |
+| `ghcr-published` | Whether GHCR successfully received an image (`true`/`false`) |
+| `artifact-published` | Whether at least one selected registry successfully received an image (`true`/`false`) |
 | `bot-detected` | Whether a bot actor was detected (`true`/`false`) |
 | `bot-evaluation-subject` | Which identity was evaluated for bot detection (`actor`, `pr-author`, or `none` when detection is disabled) |
 | `bot-evaluation-value` | The actual login value evaluated for bot detection (empty when detection is disabled) |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ All flow types use **commit SHA** (first 7 characters) for tagging, ensuring tra
 
 ### Planned main-branch releases
 
-On a push to the configured `main-branch`, set `planned-version-tag` to publish release tags without changing the event from `push`. The full value must match `release-tag-pattern`; a matching `v1.2.3` produces `1.2.3`, `1.2`, `1`, and `latest` tags (with any configured prefix or suffix). An invalid value is skipped using the same behavior as an invalid release-event tag. Omit the input to retain the normal `staging-{sha}` main-branch build.
+On a push to, or `workflow_dispatch` run from, the configured `main-branch`, set `planned-version-tag` to publish release tags. The full value must match `release-tag-pattern`; a matching `v1.2.3` produces `1.2.3`, `1.2`, `1`, and `latest` tags (with any configured prefix or suffix). An invalid value is skipped using the same behavior as an invalid release-event tag. Omit the input to retain the normal `staging-{sha}` main-branch push build or the existing manual WIP build.
 
 ```yaml
 - uses: wgtechlabs/container-build-flow-action@v1
@@ -634,7 +634,7 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 |-------|-------------|----------|---------|
 | `main-branch` | Name of main/production branch | No | `main` |
 | `dev-branch` | Name of development branch | No | `dev` |
-| `planned-version-tag` | Release tag to publish on a main-branch push; must match `release-tag-pattern` | No | `''` |
+| `planned-version-tag` | Release tag to publish on a main-branch push, or on a `workflow_dispatch` run from the main branch; ignored on other refs and must match `release-tag-pattern` | No | `''` |
 
 ### Build Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -243,6 +243,11 @@ inputs:
     required: false
     default: '^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'
 
+  planned-version-tag:
+    description: 'Release tag to publish for a push to the configured main branch. It must match release-tag-pattern.'
+    required: false
+    default: ''
+
   # Bot Detection
   bot-detection:
     description: 'Auto-detect bot actors (e.g., dependabot[bot], renovate[bot]) and skip the build. Prevents CI failures from missing secrets on bot-generated PRs.'
@@ -284,6 +289,18 @@ outputs:
   release-version:
     description: 'Clean version string from release tag (e.g., 1.2.3). Only populated for release flows.'
     value: ${{ steps.detect.outputs.release-version }}
+
+  dockerhub-published:
+    description: 'Whether an image was successfully pushed to Docker Hub (true/false).'
+    value: ${{ steps.output.outputs.dockerhub-published || 'false' }}
+
+  ghcr-published:
+    description: 'Whether an image was successfully pushed to GHCR (true/false).'
+    value: ${{ steps.output.outputs.ghcr-published || 'false' }}
+
+  artifact-published:
+    description: 'Whether at least one selected registry successfully received an image (true/false).'
+    value: ${{ steps.output.outputs.artifact-published || 'false' }}
 
   # Security Scanning Outputs
   vulnerability-scan-completed:
@@ -419,10 +436,19 @@ runs:
           echo "⚠️  Skipping build — ${BOT_SKIP_REASON}"
           exit 0
         fi
+        if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/${MAIN_BRANCH}" ] && [ -n "$PLANNED_VERSION_TAG" ]; then
+          echo "should-build=true" >> "$GITHUB_OUTPUT"
+          echo "ℹ️  Planned version tag detected on main branch — bypassing commit convention gate"
+          exit 0
+        fi
         bash ${{ github.action_path }}/scripts/detect-commit-convention.sh
       env:
         BOT_DETECTED: ${{ steps.bot-gate.outputs.is-bot }}
         BOT_SKIP_REASON: ${{ steps.bot-gate.outputs.build-skip-reason }}
+        EVENT_NAME: ${{ github.event_name }}
+        REF: ${{ github.ref }}
+        MAIN_BRANCH: ${{ inputs.main-branch }}
+        PLANNED_VERSION_TAG: ${{ inputs.planned-version-tag }}
         COMMIT_CONVENTION_ENABLED: ${{ inputs.commit-convention-enabled }}
         COMMIT_CONVENTION: ${{ inputs.commit-convention }}
         BUILD_TRIGGER_TYPES: ${{ inputs.build-trigger-types }}
@@ -445,6 +471,7 @@ runs:
         RELEASE_TAG: ${{ github.event.release.tag_name }}
         RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         RELEASE_TAG_PATTERN: ${{ inputs.release-tag-pattern }}
+        PLANNED_VERSION_TAG: ${{ inputs.planned-version-tag }}
         FLOATING_TAGS: ${{ inputs.floating-tags }}
 
     - name: Resolve Build Platforms
@@ -463,7 +490,26 @@ runs:
     - name: Set up Docker Buildx
       if: steps.commit-gate.outputs.should-build != 'false' && steps.detect.outputs.build-flow-type != 'skip'
       uses: docker/setup-buildx-action@v4
-    
+
+    - name: Normalize Push Enabled
+      id: push-enabled
+      if: ${{ !cancelled() && steps.commit-gate.outputs.should-build != 'false' && steps.detect.outputs.build-flow-type != 'skip' }}
+      shell: bash
+      env:
+        PUSH_ENABLED_INPUT: ${{ inputs.push-enabled }}
+      run: |
+        PUSH_ENABLED="${PUSH_ENABLED_INPUT#"${PUSH_ENABLED_INPUT%%[![:space:]]*}"}"
+        PUSH_ENABLED="${PUSH_ENABLED%"${PUSH_ENABLED##*[![:space:]]}"}"
+        case "$PUSH_ENABLED" in
+          true|false)
+            ;;
+          *)
+            echo "❌ Invalid push-enabled value: '${PUSH_ENABLED}'. Allowed values: true, false."
+            exit 1
+            ;;
+        esac
+        echo "value=${PUSH_ENABLED}" >> "$GITHUB_OUTPUT"
+
     # =============================================================================
     # PRE-BUILD SECURITY SCANNING
     # =============================================================================
@@ -543,28 +589,31 @@ runs:
     # =============================================================================
     
     - name: Login to Docker Hub
-      if: steps.commit-gate.outputs.should-build != 'false' && (inputs.registry == 'docker-hub' || inputs.registry == 'both') && steps.detect.outputs.build-flow-type != 'skip'
+      id: dockerhub-login
+      if: steps.commit-gate.outputs.should-build != 'false' && steps.push-enabled.outputs.value == 'true' && (inputs.registry == 'docker-hub' || inputs.registry == 'both') && steps.detect.outputs.build-flow-type != 'skip'
       uses: docker/login-action@v4
+      continue-on-error: true
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-token }}
     
     - name: Login to GitHub Container Registry
-      if: steps.commit-gate.outputs.should-build != 'false' && (inputs.registry == 'ghcr' || inputs.registry == 'both') && steps.detect.outputs.build-flow-type != 'skip'
+      id: ghcr-login
+      if: steps.commit-gate.outputs.should-build != 'false' && steps.push-enabled.outputs.value == 'true' && (inputs.registry == 'ghcr' || inputs.registry == 'both') && steps.detect.outputs.build-flow-type != 'skip'
       uses: docker/login-action@v4
+      continue-on-error: true
       with:
         registry: ghcr.io
         username: ${{ inputs.ghcr-username || github.repository_owner }}
         password: ${{ inputs.ghcr-token || github.token }}
     
-    - name: Extract Docker Metadata
-      id: meta
-      if: steps.commit-gate.outputs.should-build != 'false' && steps.detect.outputs.build-flow-type != 'skip'
+    - name: Extract Docker Hub Metadata
+      id: dockerhub-meta
+      if: steps.commit-gate.outputs.should-build != 'false' && (inputs.registry == 'docker-hub' || inputs.registry == 'both') && steps.detect.outputs.build-flow-type != 'skip'
       uses: docker/metadata-action@v6
+      continue-on-error: true
       with:
-        images: |
-          ${{ (inputs.registry == 'docker-hub' || inputs.registry == 'both') && steps.detect.outputs.dockerhub-image || '' }}
-          ${{ (inputs.registry == 'ghcr' || inputs.registry == 'both') && steps.detect.outputs.ghcr-image || '' }}
+        images: ${{ steps.detect.outputs.dockerhub-image }}
         tags: |
           type=raw,value=${{ steps.detect.outputs.tags }}
           ${{ steps.detect.outputs.extra-tags }}
@@ -574,18 +623,54 @@ runs:
           org.opencontainers.image.created=${{ github.event.repository.updated_at }}
           ${{ inputs.labels }}
     
-    - name: Build and Push Container Image
-      id: build
-      if: steps.commit-gate.outputs.should-build != 'false' && steps.detect.outputs.build-flow-type != 'skip'
+    - name: Extract GHCR Metadata
+      id: ghcr-meta
+      if: steps.commit-gate.outputs.should-build != 'false' && (inputs.registry == 'ghcr' || inputs.registry == 'both') && steps.detect.outputs.build-flow-type != 'skip'
+      uses: docker/metadata-action@v6
+      continue-on-error: true
+      with:
+        images: ${{ steps.detect.outputs.ghcr-image }}
+        tags: |
+          type=raw,value=${{ steps.detect.outputs.tags }}
+          ${{ steps.detect.outputs.extra-tags }}
+        labels: |
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          org.opencontainers.image.revision=${{ steps.sha.outputs.sha }}
+          org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+          ${{ inputs.labels }}
+
+    - name: Build and Push Docker Hub Image
+      id: dockerhub-build
+      if: steps.commit-gate.outputs.should-build != 'false' && (inputs.registry == 'docker-hub' || inputs.registry == 'both') && steps.detect.outputs.build-flow-type != 'skip' && (steps.push-enabled.outputs.value != 'true' || steps.dockerhub-login.outcome == 'success')
       uses: docker/build-push-action@v7
+      continue-on-error: true
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         platforms: ${{ steps.platforms.outputs.platforms }}
-        push: ${{ inputs.push-enabled }}
+        push: ${{ steps.push-enabled.outputs.value }}
         load: ${{ inputs.load-enabled }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.dockerhub-meta.outputs.tags }}
+        labels: ${{ steps.dockerhub-meta.outputs.labels }}
+        build-args: ${{ inputs.build-args }}
+        cache-from: ${{ inputs.cache-enabled == 'true' && 'type=gha' || '' }}
+        cache-to: ${{ inputs.cache-enabled == 'true' && 'type=gha,mode=max' || '' }}
+        provenance: ${{ inputs.provenance }}
+        sbom: ${{ inputs.sbom }}
+
+    - name: Build and Push GHCR Image
+      id: ghcr-build
+      if: steps.commit-gate.outputs.should-build != 'false' && (inputs.registry == 'ghcr' || inputs.registry == 'both') && steps.detect.outputs.build-flow-type != 'skip' && (steps.push-enabled.outputs.value != 'true' || steps.ghcr-login.outcome == 'success')
+      uses: docker/build-push-action@v7
+      continue-on-error: true
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ steps.platforms.outputs.platforms }}
+        push: ${{ steps.push-enabled.outputs.value }}
+        load: ${{ inputs.load-enabled }}
+        tags: ${{ steps.ghcr-meta.outputs.tags }}
+        labels: ${{ steps.ghcr-meta.outputs.labels }}
         build-args: ${{ inputs.build-args }}
         cache-from: ${{ inputs.cache-enabled == 'true' && 'type=gha' || '' }}
         cache-to: ${{ inputs.cache-enabled == 'true' && 'type=gha,mode=max' || '' }}
@@ -594,24 +679,36 @@ runs:
     
     - name: Generate Action Outputs
       id: output
-      if: steps.commit-gate.outputs.should-build != 'false' && steps.detect.outputs.build-flow-type != 'skip'
+      if: always() && steps.commit-gate.outputs.should-build != 'false' && steps.detect.outputs.build-flow-type != 'skip'
       shell: bash
+      continue-on-error: true
       run: |
         bash ${{ github.action_path }}/scripts/generate-outputs.sh
       env:
-        BUILD_DIGEST: ${{ steps.build.outputs.digest }}
-        BUILD_METADATA: ${{ steps.build.outputs.metadata }}
+        BUILD_DIGEST: ${{ steps.dockerhub-build.outputs.digest || steps.ghcr-build.outputs.digest }}
+        BUILD_METADATA: ${{ steps.dockerhub-build.outputs.metadata || steps.ghcr-build.outputs.metadata }}
         BUILD_FLOW_TYPE: ${{ steps.detect.outputs.build-flow-type }}
-        IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         SHORT_SHA: ${{ steps.detect.outputs.short-sha }}
         REGISTRY: ${{ inputs.registry }}
+        PUSH_ENABLED: ${{ steps.push-enabled.outputs.value }}
+        DOCKERHUB_BUILD_OUTCOME: ${{ steps.dockerhub-build.outcome }}
+        GHCR_BUILD_OUTCOME: ${{ steps.ghcr-build.outcome }}
+        DOCKERHUB_PUBLISHED: ${{ steps.push-enabled.outputs.value == 'true' && steps.dockerhub-build.outcome == 'success' }}
+        GHCR_PUBLISHED: ${{ steps.push-enabled.outputs.value == 'true' && steps.ghcr-build.outcome == 'success' }}
+        DOCKERHUB_IMAGE_TAGS: ${{ steps.dockerhub-build.outcome == 'success' && steps.dockerhub-meta.outputs.tags || '' }}
+        GHCR_IMAGE_TAGS: ${{ steps.ghcr-build.outcome == 'success' && steps.ghcr-meta.outputs.tags || '' }}
+
+    - name: Fail if all selected registry attempts failed
+      if: always() && steps.commit-gate.outputs.should-build != 'false' && steps.detect.outputs.build-flow-type != 'skip' && ((steps.push-enabled.outputs.value == 'true' && steps.output.outputs.artifact-published != 'true') || (steps.push-enabled.outputs.value != 'true' && steps.output.outcome == 'failure'))
+      shell: bash
+      run: exit 1
     
     # =============================================================================
     # POST-BUILD SECURITY SCANNING
     # =============================================================================
     
     - name: Scan Baseline Image (for comparison)
-      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.enable-image-comparison == 'true' && inputs.comparison-baseline-image != '' && steps.detect.outputs.build-flow-type != 'skip'
+      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.enable-image-comparison == 'true' && inputs.comparison-baseline-image != '' && steps.detect.outputs.build-flow-type != 'skip' && steps.output.outputs.artifact-published == 'true'
       uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
@@ -624,12 +721,12 @@ runs:
         timeout: ${{ inputs.trivy-timeout }}
     
     - name: Scan Container Image
-      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && steps.detect.outputs.build-flow-type != 'skip'
+      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && steps.detect.outputs.build-flow-type != 'skip' && steps.output.outputs.artifact-published == 'true'
       uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'image'
-        image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        image-ref: ${{ steps.output.outputs.published-image }}
         format: 'json'
         output: 'trivy-image-results.json'
         severity: ${{ inputs.trivy-severity }}
@@ -637,21 +734,21 @@ runs:
         timeout: ${{ inputs.trivy-timeout }}
     
     - name: Parse Trivy Results and Generate Summary
-      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && steps.detect.outputs.build-flow-type != 'skip'
+      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && steps.detect.outputs.build-flow-type != 'skip' && steps.output.outputs.artifact-published == 'true'
       id: scan-summary
       shell: bash
       run: |
         node ${{ github.action_path }}/dist/parse-trivy-results.js
     
     - name: Generate Vulnerability Comparison
-      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.enable-image-comparison == 'true' && steps.detect.outputs.build-flow-type != 'skip'
+      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.enable-image-comparison == 'true' && steps.detect.outputs.build-flow-type != 'skip' && steps.output.outputs.artifact-published == 'true'
       shell: bash
       continue-on-error: true
       run: |
         node ${{ github.action_path }}/dist/generate-comparison.js
     
     - name: Check Vulnerability Threshold
-      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.fail-on-vulnerability == 'true' && steps.detect.outputs.build-flow-type != 'skip'
+      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.fail-on-vulnerability == 'true' && steps.detect.outputs.build-flow-type != 'skip' && steps.output.outputs.artifact-published == 'true'
       shell: bash
       run: |
         if [ -f trivy-scan-summary.json ]; then
@@ -677,12 +774,12 @@ runs:
         fi
     
     - name: Upload Container Image Scan to GitHub Security
-      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.upload-sarif == 'true' && steps.detect.outputs.build-flow-type != 'skip'
+      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.upload-sarif == 'true' && steps.detect.outputs.build-flow-type != 'skip' && steps.output.outputs.artifact-published == 'true'
       uses: aquasecurity/trivy-action@v0.36.0
       continue-on-error: true
       with:
         scan-type: 'image'
-        image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+        image-ref: ${{ steps.output.outputs.published-image }}
         format: 'sarif'
         output: 'trivy-image-results.sarif'
         severity: ${{ inputs.trivy-severity }}
@@ -690,7 +787,7 @@ runs:
         timeout: ${{ inputs.trivy-timeout }}
     
     - name: Upload Image Scan SARIF
-      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.upload-sarif == 'true' && steps.detect.outputs.build-flow-type != 'skip'
+      if: steps.commit-gate.outputs.should-build != 'false' && inputs.image-scan-enabled == 'true' && inputs.upload-sarif == 'true' && steps.detect.outputs.build-flow-type != 'skip' && steps.output.outputs.artifact-published == 'true'
       uses: github/codeql-action/upload-sarif@v4
       continue-on-error: true
       with:

--- a/action.yml
+++ b/action.yml
@@ -436,7 +436,7 @@ runs:
           echo "⚠️  Skipping build — ${BOT_SKIP_REASON}"
           exit 0
         fi
-        if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/${MAIN_BRANCH}" ] && [ -n "$PLANNED_VERSION_TAG" ]; then
+        if { [ "$EVENT_NAME" = "push" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; } && [ "$REF" = "refs/heads/${MAIN_BRANCH}" ] && [ -n "$PLANNED_VERSION_TAG" ]; then
           echo "should-build=true" >> "$GITHUB_OUTPUT"
           echo "ℹ️  Planned version tag detected on main branch — bypassing commit convention gate"
           exit 0

--- a/bun.lock
+++ b/bun.lock
@@ -5,16 +5,16 @@
     "": {
       "name": "container-build-flow-action",
       "devDependencies": {
-        "@types/node": "^22.0.0",
-        "typescript": "^5.7.0",
+        "@types/node": "^25.3.2",
+        "typescript": "^6.0.2",
       },
     },
   },
   "packages": {
-    "@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
+    "@types/node": ["@types/node@25.9.5", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "bun build src/parse-trivy-results.ts --outdir dist --target node --format cjs && bun build src/generate-comparison.ts --outdir dist --target node --format cjs && bun build src/pr-comment.ts --outdir dist --target node --format cjs",
     "clean": "rm -rf dist",
     "rebuild": "bun run clean && bun run build",
+    "test": "bash tests/test-container-build-flow.sh",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/scripts/detect-build-flow.sh
+++ b/scripts/detect-build-flow.sh
@@ -205,8 +205,8 @@ detect_build_flow() {
             log_warning "Flow: Work in progress (non-standard PR)"
         fi
         
-    elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
-        log_info "Push event detected"
+    elif [ "$GITHUB_EVENT_NAME" = "push" ] || { [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$GITHUB_REF" = "refs/heads/${MAIN_BRANCH}" ] && [ -n "$PLANNED_VERSION_TAG" ]; }; then
+        log_info "Push or planned manual release detected"
         
         # Extract branch name from ref
         local branch="${GITHUB_REF#refs/heads/}"

--- a/scripts/detect-build-flow.sh
+++ b/scripts/detect-build-flow.sh
@@ -225,6 +225,8 @@ detect_build_flow() {
 
                 if [[ -n "${RELEASE_TAG_PATTERN}" ]] && ! [[ "${PLANNED_VERSION_TAG}" =~ ${RELEASE_TAG_PATTERN} ]]; then
                     log_warning "Skipping build: tag '${PLANNED_VERSION_TAG}' does not match pattern '${RELEASE_TAG_PATTERN}'"
+                    # Surface the rejected planned tag in the skip summary
+                    RELEASE_TAG="$PLANNED_VERSION_TAG"
                     flow_type="skip"
                 else
                     if [[ "$PLANNED_VERSION_TAG" =~ ^v[0-9] ]]; then

--- a/scripts/detect-build-flow.sh
+++ b/scripts/detect-build-flow.sh
@@ -48,6 +48,7 @@ GITHUB_BASE_REF="${GITHUB_BASE_REF:-}"
 RELEASE_TAG="${RELEASE_TAG:-}"
 RELEASE_PRERELEASE="${RELEASE_PRERELEASE:-false}"
 RELEASE_TAG_PATTERN="${RELEASE_TAG_PATTERN-^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$}"
+PLANNED_VERSION_TAG="${PLANNED_VERSION_TAG:-}"
 
 # User-configurable inputs (from action.yml)
 MAIN_BRANCH="${MAIN_BRANCH:-main}"
@@ -103,7 +104,7 @@ get_repo_name() {
 # Extract prerelease identifier from semver (e.g., "beta" from "1.2.3-beta.1")
 extract_prerelease_id() {
     local version="$1"
-    if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-([a-zA-Z][0-9A-Za-z-]*) ]]; then
+    if [[ "$version" =~ [0-9]+\.[0-9]+\.[0-9]+-([0-9A-Za-z-]+) ]]; then
         echo "${BASH_REMATCH[1]}"
     else
         echo ""
@@ -162,6 +163,7 @@ detect_build_flow() {
     log_debug "Configuration:"
     log_debug "  Main Branch: ${MAIN_BRANCH}"
     log_debug "  Dev Branch: ${DEV_BRANCH}"
+    log_debug "  Planned Version Tag: ${PLANNED_VERSION_TAG:-<not set>}"
     
     local flow_type=""
     local release_version=""
@@ -215,10 +217,33 @@ detect_build_flow() {
             flow_type="dev"
             log_success "Flow: Push to dev branch"
             
-        # Push to main branch -> staging for pre-production validation
+        # Push to main branch -> staging, unless a validated release tag is planned
         elif [ "$branch" = "$MAIN_BRANCH" ]; then
-            flow_type="staging"
-            log_success "Flow: Push to main branch (staging)"
+            if [ -n "$PLANNED_VERSION_TAG" ]; then
+                log_debug "  Planned Version Tag: ${PLANNED_VERSION_TAG}"
+                log_debug "  Release Tag Pattern: ${RELEASE_TAG_PATTERN}"
+
+                if [[ -n "${RELEASE_TAG_PATTERN}" ]] && ! [[ "${PLANNED_VERSION_TAG}" =~ ${RELEASE_TAG_PATTERN} ]]; then
+                    log_warning "Skipping build: tag '${PLANNED_VERSION_TAG}' does not match pattern '${RELEASE_TAG_PATTERN}'"
+                    flow_type="skip"
+                else
+                    if [[ "$PLANNED_VERSION_TAG" =~ ^v[0-9] ]]; then
+                        release_version="${PLANNED_VERSION_TAG#v}"
+                    else
+                        release_version="$PLANNED_VERSION_TAG"
+                    fi
+                    if [[ "$release_version" =~ [0-9]+\.[0-9]+\.[0-9]+- ]]; then
+                        RELEASE_PRERELEASE=true
+                    else
+                        RELEASE_PRERELEASE=false
+                    fi
+                    flow_type="release"
+                    log_success "Flow: Planned production release (${release_version})"
+                fi
+            else
+                flow_type="staging"
+                log_success "Flow: Push to main branch (staging)"
+            fi
             
         # Push to any other branch -> wip-{sha}
         else
@@ -296,32 +321,28 @@ detect_build_flow() {
         log_debug "  Primary tag: ${full_tag}"
 
         # Generate additional tags for releases
-        if parse_semver "$release_version"; then
-            if [ "$RELEASE_PRERELEASE" = "true" ]; then
-                # Pre-release: add channel tag (e.g., "beta" from "1.2.3-beta.1")
-                local prerelease_id
-                prerelease_id=$(extract_prerelease_id "$release_version")
-                if [ -n "$prerelease_id" ]; then
-                    extra_tags="type=raw,value=${TAG_PREFIX}${prerelease_id}${TAG_SUFFIX}"
-                    log_debug "  Pre-release channel tag: ${prerelease_id}"
-                fi
-            else
-                # Standard release: add major, minor, and latest tags
-                extra_tags="type=raw,value=${TAG_PREFIX}${SEMVER_MAJOR}.${SEMVER_MINOR}${TAG_SUFFIX}"
-                extra_tags="${extra_tags}
-type=raw,value=${TAG_PREFIX}${SEMVER_MAJOR}${TAG_SUFFIX}"
-                extra_tags="${extra_tags}
-type=raw,value=${TAG_PREFIX}latest${TAG_SUFFIX}"
-                log_debug "  Minor tag: ${SEMVER_MAJOR}.${SEMVER_MINOR}"
-                log_debug "  Major tag: ${SEMVER_MAJOR}"
-                log_debug "  Latest tag: latest"
+        if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            # Pre-release: add channel tag (e.g., "beta" from "1.2.3-beta.1")
+            local prerelease_id
+            prerelease_id=$(extract_prerelease_id "$release_version")
+            if [ -n "$prerelease_id" ]; then
+                extra_tags="type=raw,value=${TAG_PREFIX}${prerelease_id}${TAG_SUFFIX}"
+                log_debug "  Pre-release channel tag: ${prerelease_id}"
             fi
+        elif parse_semver "$release_version"; then
+            # Standard release: add major, minor, and latest tags
+            extra_tags="type=raw,value=${TAG_PREFIX}${SEMVER_MAJOR}.${SEMVER_MINOR}${TAG_SUFFIX}"
+            extra_tags="${extra_tags}
+type=raw,value=${TAG_PREFIX}${SEMVER_MAJOR}${TAG_SUFFIX}"
+            extra_tags="${extra_tags}
+type=raw,value=${TAG_PREFIX}latest${TAG_SUFFIX}"
+            log_debug "  Minor tag: ${SEMVER_MAJOR}.${SEMVER_MINOR}"
+            log_debug "  Major tag: ${SEMVER_MAJOR}"
+            log_debug "  Latest tag: latest"
         else
             # Non-semver tag: just use the version as-is, add latest for non-prerelease
-            if [ "$RELEASE_PRERELEASE" != "true" ]; then
-                extra_tags="type=raw,value=${TAG_PREFIX}latest${TAG_SUFFIX}"
-                log_debug "  Latest tag: latest"
-            fi
+            extra_tags="type=raw,value=${TAG_PREFIX}latest${TAG_SUFFIX}"
+            log_debug "  Latest tag: latest"
         fi
     else
         # Non-release flows: existing behavior

--- a/scripts/generate-outputs.sh
+++ b/scripts/generate-outputs.sh
@@ -35,6 +35,13 @@ BUILD_FLOW_TYPE="${BUILD_FLOW_TYPE:-}"
 IMAGE_TAGS="${IMAGE_TAGS:-}"
 SHORT_SHA="${SHORT_SHA:-}"
 REGISTRY="${REGISTRY:-both}"
+DOCKERHUB_PUBLISHED="${DOCKERHUB_PUBLISHED:-false}"
+GHCR_PUBLISHED="${GHCR_PUBLISHED:-false}"
+PUSH_ENABLED="${PUSH_ENABLED:-true}"
+DOCKERHUB_BUILD_OUTCOME="${DOCKERHUB_BUILD_OUTCOME:-}"
+GHCR_BUILD_OUTCOME="${GHCR_BUILD_OUTCOME:-}"
+DOCKERHUB_IMAGE_TAGS="${DOCKERHUB_IMAGE_TAGS:-}"
+GHCR_IMAGE_TAGS="${GHCR_IMAGE_TAGS:-}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -158,6 +165,78 @@ format_build_digest() {
 }
 
 # =============================================================================
+# PUBLISH RESULTS
+# =============================================================================
+
+normalize_publish_results() {
+    case "$REGISTRY" in
+        docker-hub)
+            GHCR_PUBLISHED="false"
+            ;;
+        ghcr)
+            DOCKERHUB_PUBLISHED="false"
+            ;;
+        both)
+            ;;
+        *)
+            log_warning "Unknown registry type: ${REGISTRY}"
+            DOCKERHUB_PUBLISHED="false"
+            GHCR_PUBLISHED="false"
+            ;;
+    esac
+
+    if [ "$DOCKERHUB_PUBLISHED" != "true" ]; then
+        DOCKERHUB_PUBLISHED="false"
+    fi
+    if [ "$GHCR_PUBLISHED" != "true" ]; then
+        GHCR_PUBLISHED="false"
+    fi
+
+    if [ "$DOCKERHUB_PUBLISHED" = "true" ] || [ "$GHCR_PUBLISHED" = "true" ]; then
+        ARTIFACT_PUBLISHED="true"
+    else
+        ARTIFACT_PUBLISHED="false"
+    fi
+
+    if [ "$ARTIFACT_PUBLISHED" = "true" ]; then
+        IMAGE_TAGS=""
+        PUBLISHED_IMAGE=""
+        if [ "$DOCKERHUB_PUBLISHED" = "true" ]; then
+            IMAGE_TAGS="$DOCKERHUB_IMAGE_TAGS"
+            PUBLISHED_IMAGE=$(printf '%s\n' "$DOCKERHUB_IMAGE_TAGS" | head -n1)
+        fi
+        if [ "$GHCR_PUBLISHED" = "true" ]; then
+            IMAGE_TAGS="${IMAGE_TAGS:+${IMAGE_TAGS}$'\n'}${GHCR_IMAGE_TAGS}"
+            if [ -z "$PUBLISHED_IMAGE" ]; then
+                PUBLISHED_IMAGE=$(printf '%s\n' "$GHCR_IMAGE_TAGS" | head -n1)
+            fi
+        fi
+    else
+        PUBLISHED_IMAGE=""
+        if [ "$PUSH_ENABLED" != "true" ]; then
+            IMAGE_TAGS="${DOCKERHUB_IMAGE_TAGS}${DOCKERHUB_IMAGE_TAGS:+$'\n'}${GHCR_IMAGE_TAGS}"
+        fi
+    fi
+}
+
+selected_build_succeeded() {
+    case "$REGISTRY" in
+        docker-hub)
+            [ "$DOCKERHUB_BUILD_OUTCOME" = "success" ]
+            ;;
+        ghcr)
+            [ "$GHCR_BUILD_OUTCOME" = "success" ]
+            ;;
+        both)
+            [ "$DOCKERHUB_BUILD_OUTCOME" = "success" ] || [ "$GHCR_BUILD_OUTCOME" = "success" ]
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# =============================================================================
 # VALIDATION
 # =============================================================================
 
@@ -195,6 +274,8 @@ validate_inputs() {
 generate_outputs() {
     log_info "Generating GitHub Actions outputs..."
     
+    normalize_publish_results
+
     # Process all outputs
     local formatted_tags registry_urls formatted_digest
     
@@ -212,6 +293,10 @@ generate_outputs() {
             echo "build-digest=${formatted_digest}"
             echo "build-flow-type=${BUILD_FLOW_TYPE}"
             echo "short-sha=${SHORT_SHA}"
+            echo "dockerhub-published=${DOCKERHUB_PUBLISHED}"
+            echo "ghcr-published=${GHCR_PUBLISHED}"
+            echo "artifact-published=${ARTIFACT_PUBLISHED}"
+            echo "published-image=${PUBLISHED_IMAGE}"
         } >> "$GITHUB_OUTPUT"
         
         log_success "Outputs written to GitHub Actions"
@@ -226,6 +311,9 @@ generate_outputs() {
     echo -e "  ${CYAN}Short SHA:${NC} ${SHORT_SHA}"
     echo -e "  ${CYAN}Image Tags:${NC} ${formatted_tags}"
     echo -e "  ${CYAN}Build Digest:${NC} ${formatted_digest}"
+    echo -e "  ${CYAN}Docker Hub Published:${NC} ${DOCKERHUB_PUBLISHED}"
+    echo -e "  ${CYAN}GHCR Published:${NC} ${GHCR_PUBLISHED}"
+    echo -e "  ${CYAN}Artifact Published:${NC} ${ARTIFACT_PUBLISHED}"
     echo ""
     echo -e "  ${CYAN}Registry URLs:${NC}"
     echo "$registry_urls" | while IFS= read -r line; do
@@ -251,6 +339,15 @@ main() {
     generate_outputs
     
     echo ""
+    if [ "$PUSH_ENABLED" = "true" ] && [ "$ARTIFACT_PUBLISHED" != "true" ]; then
+        log_error "All selected registry publish attempts failed"
+        exit 1
+    fi
+    if [ "$PUSH_ENABLED" != "true" ] && ! selected_build_succeeded; then
+        log_error "All selected registry build attempts failed"
+        exit 1
+    fi
+
     log_success "Step 4: Output generation complete!"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 }

--- a/scripts/generate-outputs.sh
+++ b/scripts/generate-outputs.sh
@@ -169,6 +169,8 @@ format_build_digest() {
 # =============================================================================
 
 normalize_publish_results() {
+    local newline=$'\n'
+
     case "$REGISTRY" in
         docker-hub)
             GHCR_PUBLISHED="false"
@@ -206,7 +208,7 @@ normalize_publish_results() {
             PUBLISHED_IMAGE=$(printf '%s\n' "$DOCKERHUB_IMAGE_TAGS" | head -n1)
         fi
         if [ "$GHCR_PUBLISHED" = "true" ]; then
-            IMAGE_TAGS="${IMAGE_TAGS:+${IMAGE_TAGS}$'\n'}${GHCR_IMAGE_TAGS}"
+            IMAGE_TAGS="${IMAGE_TAGS:+${IMAGE_TAGS}${newline}}${GHCR_IMAGE_TAGS}"
             if [ -z "$PUBLISHED_IMAGE" ]; then
                 PUBLISHED_IMAGE=$(printf '%s\n' "$GHCR_IMAGE_TAGS" | head -n1)
             fi
@@ -214,7 +216,7 @@ normalize_publish_results() {
     else
         PUBLISHED_IMAGE=""
         if [ "$PUSH_ENABLED" != "true" ]; then
-            IMAGE_TAGS="${DOCKERHUB_IMAGE_TAGS}${DOCKERHUB_IMAGE_TAGS:+$'\n'}${GHCR_IMAGE_TAGS}"
+            IMAGE_TAGS="${DOCKERHUB_IMAGE_TAGS}${DOCKERHUB_IMAGE_TAGS:+${newline}}${GHCR_IMAGE_TAGS}"
         fi
     fi
 }

--- a/tests/test-container-build-flow.sh
+++ b/tests/test-container-build-flow.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DETECT_SCRIPT="$ROOT/scripts/detect-build-flow.sh"
+OUTPUT_SCRIPT="$ROOT/scripts/generate-outputs.sh"
+SHA="0123456789abcdef"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+output_value() {
+    local file="$1"
+    local key="$2"
+    grep "^${key}=" "$file" | tail -n1 | cut -d= -f2-
+}
+
+run_detect() {
+    local planned_tag="$1"
+    local release_tag_pattern="${2:-}"
+    local tag_prefix="${3-release-}"
+    local tag_suffix="${4--alpine}"
+    local output_file
+    local -a env_args
+    output_file="$(mktemp)"
+
+    env_args=(
+        GITHUB_EVENT_NAME=push
+        GITHUB_REF=refs/heads/main
+        GITHUB_SHA="$SHA"
+        GITHUB_REPOSITORY=example/widget
+        GITHUB_REPOSITORY_OWNER=example
+        GITHUB_OUTPUT="$output_file"
+        MAIN_BRANCH=main
+        DEV_BRANCH=dev
+        PLANNED_VERSION_TAG="$planned_tag"
+        TAG_PREFIX="$tag_prefix"
+        TAG_SUFFIX="$tag_suffix"
+    )
+    if [ -n "$release_tag_pattern" ]; then
+        env_args+=(RELEASE_TAG_PATTERN="$release_tag_pattern")
+    fi
+    env "${env_args[@]}" bash "$DETECT_SCRIPT" >/dev/null
+
+    cat "$output_file"
+    rm -f "$output_file"
+}
+
+assert_planned_main_release() {
+    local output
+    output="$(run_detect v1.2.3)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "release" ]] ||
+        fail "planned tag must produce a release flow"
+    [[ "$(printf '%s\n' "$output" | grep '^tags=' | cut -d= -f2-)" == "release-1.2.3-alpine" ]] ||
+        fail "planned tag must strip only its leading v and respect tag prefix/suffix"
+    printf '%s\n' "$output" | grep -q '^type=raw,value=release-1.2-alpine$' ||
+        fail "planned tag must include its minor release tag"
+    printf '%s\n' "$output" | grep -q '^type=raw,value=release-1-alpine$' ||
+        fail "planned tag must include its major release tag"
+    printf '%s\n' "$output" | grep -q '^type=raw,value=release-latest-alpine$' ||
+        fail "planned tag must include latest"
+}
+
+assert_planned_custom_pattern_preserves_version_prefix() {
+    local output
+    output="$(run_detect version-1.2.3 '^version-[0-9]+\.[0-9]+\.[0-9]+$' "" "")"
+
+    [[ "$(printf '%s\n' "$output" | grep '^tags=' | cut -d= -f2-)" == "version-1.2.3" ]] ||
+        fail "planned tags that do not start with v followed by a digit must remain unchanged"
+}
+
+assert_planned_main_prerelease() {
+    local output
+    output="$(run_detect v1.2.3-rc.1)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "release" ]] ||
+        fail "planned prerelease tag must produce a release flow"
+    [[ "$(printf '%s\n' "$output" | grep '^tags=' | cut -d= -f2-)" == "release-1.2.3-rc.1-alpine" ]] ||
+        fail "planned prerelease tag must use its exact version tag"
+    printf '%s\n' "$output" | grep -q '^type=raw,value=release-rc-alpine$' ||
+        fail "planned prerelease tag must include its channel tag"
+    if printf '%s\n' "$output" | grep -Eq '^type=raw,value=release-(1\.2|1|latest)-alpine$'; then
+        fail "planned prerelease tag must not include production floating tags"
+    fi
+}
+
+assert_planned_numeric_prerelease() {
+    local output
+    output="$(run_detect v1.2.3-1)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^tags=' | cut -d= -f2-)" == "release-1.2.3-1-alpine" ]] ||
+        fail "planned numeric prerelease must use its exact version tag"
+    [[ "$(printf '%s\n' "$output" | grep -c '^type=raw,value=release-1-alpine$')" == "1" ]] ||
+        fail "planned numeric prerelease must include only its numeric channel tag"
+    if printf '%s\n' "$output" | grep -Eq '^type=raw,value=release-(1\.2|latest)-alpine$'; then
+        fail "planned numeric prerelease must not include production floating tags"
+    fi
+}
+
+assert_planned_custom_pattern_prerelease() {
+    local output
+    output="$(run_detect prefix-1.2.3-rc.1 '^prefix-[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z0-9.-]+$' "" "")"
+
+    [[ "$(printf '%s\n' "$output" | grep '^tags=' | cut -d= -f2-)" == "prefix-1.2.3-rc.1" ]] ||
+        fail "custom-pattern prerelease must use its exact version tag"
+    printf '%s\n' "$output" | grep -q '^type=raw,value=rc$' ||
+        fail "custom-pattern prerelease must include its channel tag"
+    if printf '%s\n' "$output" | grep -q '^type=raw,value=latest$'; then
+        fail "custom-pattern prerelease must not include latest"
+    fi
+}
+
+assert_omitted_planned_tag_stages_main() {
+    local output
+    output="$(run_detect "")"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "staging" ]] ||
+        fail "main pushes without a planned tag must remain staging"
+}
+
+assert_invalid_planned_tag_skips_main() {
+    local output
+    output="$(run_detect invalid-tag)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "skip" ]] ||
+        fail "main pushes with an invalid planned tag must skip"
+}
+
+run_output() {
+    local registry="$1"
+    local dockerhub_published="$2"
+    local ghcr_published="$3"
+    local push_enabled="$4"
+    local dockerhub_build_outcome="${5:-success}"
+    local ghcr_build_outcome="${6:-success}"
+    local output_file
+    local dockerhub_tags=""
+    local ghcr_tags=""
+    output_file="$(mktemp)"
+
+    if [ "$dockerhub_published" = "true" ]; then
+        dockerhub_tags="example/widget:1.2.3"
+    fi
+    if [ "$ghcr_published" = "true" ]; then
+        ghcr_tags="ghcr.io/example/widget:1.2.3"
+    fi
+
+    if ! BUILD_DIGEST="sha256:example" \
+        BUILD_FLOW_TYPE=release \
+        IMAGE_TAGS="example/widget:1.2.3" \
+        SHORT_SHA="${SHA:0:7}" \
+        REGISTRY="$registry" \
+        DOCKERHUB_PUBLISHED="$dockerhub_published" \
+        GHCR_PUBLISHED="$ghcr_published" \
+        DOCKERHUB_BUILD_OUTCOME="$dockerhub_build_outcome" \
+        GHCR_BUILD_OUTCOME="$ghcr_build_outcome" \
+        PUSH_ENABLED="$push_enabled" \
+        DOCKERHUB_IMAGE_TAGS="$dockerhub_tags" \
+        GHCR_IMAGE_TAGS="$ghcr_tags" \
+        GITHUB_OUTPUT="$output_file" \
+        bash "$OUTPUT_SCRIPT" >/dev/null; then
+        cat "$output_file"
+        rm -f "$output_file"
+        return 1
+    fi
+
+    cat "$output_file"
+    rm -f "$output_file"
+}
+
+assert_registry_aggregation() {
+    local output
+    output="$(run_output both false true true)"
+    [[ "$(printf '%s\n' "$output" | grep '^dockerhub-published=' | cut -d= -f2-)" == "false" ]] ||
+        fail "Docker Hub must report false when only GHCR succeeds"
+    [[ "$(printf '%s\n' "$output" | grep '^ghcr-published=' | cut -d= -f2-)" == "true" ]] ||
+        fail "GHCR must report true when it succeeds"
+    [[ "$(printf '%s\n' "$output" | grep '^artifact-published=' | cut -d= -f2-)" == "true" ]] ||
+        fail "a GHCR-only success must publish an artifact"
+    [[ "$(printf '%s\n' "$output" | grep '^image-tags=' | cut -d= -f2-)" == "ghcr.io/example/widget:1.2.3" ]] ||
+        fail "a GHCR-only success must expose only its GHCR image tag"
+
+    output="$(run_output both true false true)"
+    [[ "$(printf '%s\n' "$output" | grep '^artifact-published=' | cut -d= -f2-)" == "true" ]] ||
+        fail "a Docker Hub-only success must publish an artifact"
+    [[ "$(printf '%s\n' "$output" | grep '^image-tags=' | cut -d= -f2-)" == "example/widget:1.2.3" ]] ||
+        fail "a Docker Hub-only success must expose only its Docker Hub image tag"
+
+    if output="$(run_output both false false true)"; then
+        fail "both selected registry failures must fail after writing outputs"
+    fi
+    [[ "$(printf '%s\n' "$output" | grep '^artifact-published=' | cut -d= -f2-)" == "false" ]] ||
+        fail "both selected registry failures must report artifact-published=false"
+}
+
+assert_no_push_registry_aggregation() {
+    local output
+    output="$(run_output both false false false success failure)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^artifact-published=' | cut -d= -f2-)" == "false" ]] ||
+        fail "no-push builds with no registry results must report artifact-published=false"
+
+    if output="$(run_output both false false false failure failure)"; then
+        fail "no-push builds must fail when all selected builds fail"
+    fi
+}
+
+action_step() {
+    local name="$1"
+
+    awk -v name="$name" '
+        /^    - name: / {
+            if (capture) {
+                exit
+            }
+            capture = index($0, "- name: " name) > 0
+        }
+        capture {
+            print
+        }
+    ' "$ROOT/action.yml"
+}
+
+assert_registry_builds_require_successful_logins_when_pushing() {
+    local dockerhub_login
+    local ghcr_login
+    local dockerhub_build
+    local ghcr_build
+
+    dockerhub_login="$(action_step "Login to Docker Hub")"
+    ghcr_login="$(action_step "Login to GitHub Container Registry")"
+    dockerhub_build="$(action_step "Build and Push Docker Hub Image")"
+    ghcr_build="$(action_step "Build and Push GHCR Image")"
+
+    [[ "$dockerhub_login" == *"id: dockerhub-login"* ]] ||
+        fail "Docker Hub login must have a stable ID"
+    [[ "$ghcr_login" == *"id: ghcr-login"* ]] ||
+        fail "GHCR login must have a stable ID"
+    [[ "$dockerhub_login" == *"continue-on-error: true"* ]] ||
+        fail "Docker Hub login must remain independently attempted"
+    [[ "$ghcr_login" == *"continue-on-error: true"* ]] ||
+        fail "GHCR login must remain independently attempted"
+    [[ "$dockerhub_build" == *"steps.push-enabled.outputs.value != 'true' || steps.dockerhub-login.outcome == 'success'"* ]] ||
+        fail "Docker Hub push builds must require a successful Docker Hub login"
+    [[ "$ghcr_build" == *"steps.push-enabled.outputs.value != 'true' || steps.ghcr-login.outcome == 'success'"* ]] ||
+        fail "GHCR push builds must require a successful GHCR login"
+}
+
+assert_push_enabled_normalization_contract() {
+    local normalizer
+    local dockerhub_login
+    local ghcr_login
+    local dockerhub_build
+    local ghcr_build
+    local outputs
+    local failure_guard
+
+    normalizer="$(action_step "Normalize Push Enabled")"
+    dockerhub_login="$(action_step "Login to Docker Hub")"
+    ghcr_login="$(action_step "Login to GitHub Container Registry")"
+    dockerhub_build="$(action_step "Build and Push Docker Hub Image")"
+    ghcr_build="$(action_step "Build and Push GHCR Image")"
+    outputs="$(action_step "Generate Action Outputs")"
+    failure_guard="$(action_step "Fail if all selected registry attempts failed")"
+
+    [[ "$normalizer" == *"id: push-enabled"* ]] ||
+        fail "push-enabled must have a stable normalizer step ID"
+    [[ "$normalizer" == *"!cancelled()"* ]] ||
+        fail "push-enabled normalizer must not run for canceled flows"
+    [[ "$normalizer" == *"steps.commit-gate.outputs.should-build != 'false'"* ]] ||
+        fail "push-enabled normalizer must not run for commit-gated flows"
+    [[ "$normalizer" == *"steps.detect.outputs.build-flow-type != 'skip'"* ]] ||
+        fail "push-enabled normalizer must not run for skipped flows"
+    [[ "$normalizer" == *"PUSH_ENABLED_INPUT: \${{ inputs.push-enabled }}"* ]] ||
+        fail "push-enabled normalizer must receive the raw action input"
+    [[ "$normalizer" == *'PUSH_ENABLED="${PUSH_ENABLED_INPUT#"${PUSH_ENABLED_INPUT%%[![:space:]]*}"}"'* ]] ||
+        fail "push-enabled normalizer must trim leading whitespace"
+    [[ "$normalizer" == *'PUSH_ENABLED="${PUSH_ENABLED%"${PUSH_ENABLED##*[![:space:]]}"}"'* ]] ||
+        fail "push-enabled normalizer must trim trailing whitespace"
+    [[ "$normalizer" == *'case "$PUSH_ENABLED" in'* && "$normalizer" == *"true|false)"* ]] ||
+        fail "push-enabled normalizer must reject values other than true or false"
+    [[ "$normalizer" == *'echo "value=${PUSH_ENABLED}" >> "$GITHUB_OUTPUT"'* ]] ||
+        fail "push-enabled normalizer must emit its canonical output"
+
+    [[ "$dockerhub_login" == *"steps.push-enabled.outputs.value == 'true'"* ]] ||
+        fail "Docker Hub login must use canonical push-enabled=true"
+    [[ "$ghcr_login" == *"steps.push-enabled.outputs.value == 'true'"* ]] ||
+        fail "GHCR login must use canonical push-enabled=true"
+    [[ "$dockerhub_build" == *"steps.push-enabled.outputs.value != 'true' || steps.dockerhub-login.outcome == 'success'"* ]] ||
+        fail "Docker Hub build must use canonical push-enabled for its login requirement"
+    [[ "$ghcr_build" == *"steps.push-enabled.outputs.value != 'true' || steps.ghcr-login.outcome == 'success'"* ]] ||
+        fail "GHCR build must use canonical push-enabled for its login requirement"
+    [[ "$dockerhub_build" == *'push: ${{ steps.push-enabled.outputs.value }}'* ]] ||
+        fail "Docker Hub build must use canonical push-enabled"
+    [[ "$ghcr_build" == *'push: ${{ steps.push-enabled.outputs.value }}'* ]] ||
+        fail "GHCR build must use canonical push-enabled"
+    [[ "$outputs" == *'PUSH_ENABLED: ${{ steps.push-enabled.outputs.value }}'* ]] ||
+        fail "output aggregation must receive canonical push-enabled"
+    [[ "$outputs" == *"steps.push-enabled.outputs.value == 'true' && steps.dockerhub-build.outcome == 'success'"* ]] ||
+        fail "Docker Hub publication aggregation must use canonical push-enabled"
+    [[ "$outputs" == *"steps.push-enabled.outputs.value == 'true' && steps.ghcr-build.outcome == 'success'"* ]] ||
+        fail "GHCR publication aggregation must use canonical push-enabled"
+    [[ "$failure_guard" == *"steps.push-enabled.outputs.value == 'true'"* &&
+       "$failure_guard" == *"steps.push-enabled.outputs.value != 'true'"* ]] ||
+        fail "aggregate failure guard must use canonical push-enabled"
+}
+
+assert_planned_main_release
+assert_planned_custom_pattern_preserves_version_prefix
+assert_planned_main_prerelease
+assert_planned_numeric_prerelease
+assert_planned_custom_pattern_prerelease
+assert_omitted_planned_tag_stages_main
+assert_invalid_planned_tag_skips_main
+assert_registry_aggregation
+assert_no_push_registry_aggregation
+assert_registry_builds_require_successful_logins_when_pushing
+assert_push_enabled_normalization_contract
+
+echo "PASS: container build flow behavior"

--- a/tests/test-container-build-flow.sh
+++ b/tests/test-container-build-flow.sh
@@ -23,12 +23,13 @@ run_detect() {
     local release_tag_pattern="${2:-}"
     local tag_prefix="${3-release-}"
     local tag_suffix="${4--alpine}"
+    local event_name="${5:-push}"
     local output_file
     local -a env_args
     output_file="$(mktemp)"
 
     env_args=(
-        GITHUB_EVENT_NAME=push
+        GITHUB_EVENT_NAME="$event_name"
         GITHUB_REF=refs/heads/main
         GITHUB_SHA="$SHA"
         GITHUB_REPOSITORY=example/widget
@@ -36,10 +37,17 @@ run_detect() {
         GITHUB_OUTPUT="$output_file"
         MAIN_BRANCH=main
         DEV_BRANCH=dev
-        PLANNED_VERSION_TAG="$planned_tag"
         TAG_PREFIX="$tag_prefix"
         TAG_SUFFIX="$tag_suffix"
     )
+    # Release events receive their tag through RELEASE_TAG only; every other
+    # event goes through PLANNED_VERSION_TAG. Keeping them separate prevents the
+    # tests from masking a flow that reads the wrong variable.
+    if [ "$event_name" = "release" ]; then
+        env_args+=(RELEASE_TAG="$planned_tag")
+    else
+        env_args+=(PLANNED_VERSION_TAG="$planned_tag")
+    fi
     if [ -n "$release_tag_pattern" ]; then
         env_args+=(RELEASE_TAG_PATTERN="$release_tag_pattern")
     fi
@@ -128,6 +136,40 @@ assert_invalid_planned_tag_skips_main() {
 
     [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "skip" ]] ||
         fail "main pushes with an invalid planned tag must skip"
+}
+
+assert_planned_dispatch_release() {
+    local output
+    output="$(run_detect v1.2.3 "" "" "" workflow_dispatch)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "release" ]] ||
+        fail "planned tag must produce a release flow when dispatching main"
+    [[ "$(printf '%s\n' "$output" | grep '^tags=' | cut -d= -f2-)" == "1.2.3" ]] ||
+        fail "planned dispatch tag must generate its release version"
+}
+
+assert_omitted_planned_tag_keeps_dispatch_wip() {
+    local output
+    output="$(run_detect "" "" "" "" workflow_dispatch)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "wip" ]] ||
+        fail "manual main dispatches without a planned tag must remain WIP"
+}
+
+assert_invalid_planned_dispatch_skips_main() {
+    local output
+    output="$(run_detect invalid-tag "" "" "" workflow_dispatch)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "skip" ]] ||
+        fail "invalid planned tags must skip when dispatching main"
+}
+
+assert_release_event_remains_release() {
+    local output
+    output="$(run_detect v1.2.3 "" "" "" release)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "release" ]] ||
+        fail "release events must remain release flows"
 }
 
 run_output() {
@@ -309,6 +351,14 @@ assert_push_enabled_normalization_contract() {
         fail "aggregate failure guard must use canonical push-enabled"
 }
 
+assert_planned_dispatch_bypasses_commit_gate() {
+    local commit_gate
+    commit_gate="$(action_step "Commit Convention Gate")"
+
+    [[ "$commit_gate" == *'workflow_dispatch'* ]] ||
+        fail "planned main dispatches must bypass the commit convention gate"
+}
+
 assert_planned_main_release
 assert_planned_custom_pattern_preserves_version_prefix
 assert_planned_main_prerelease
@@ -316,9 +366,14 @@ assert_planned_numeric_prerelease
 assert_planned_custom_pattern_prerelease
 assert_omitted_planned_tag_stages_main
 assert_invalid_planned_tag_skips_main
+assert_planned_dispatch_release
+assert_omitted_planned_tag_keeps_dispatch_wip
+assert_invalid_planned_dispatch_skips_main
+assert_release_event_remains_release
 assert_registry_aggregation
 assert_no_push_registry_aggregation
 assert_registry_builds_require_successful_logins_when_pushing
 assert_push_enabled_normalization_contract
+assert_planned_dispatch_bypasses_commit_gate
 
 echo "PASS: container build flow behavior"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "declaration": false,
     "sourceMap": false,
     "noEmit": true,
-    "moduleResolution": "node"
+    "ignoreDeprecations": "6.0",
+    "moduleResolution": "node",
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Release scope

Promotes planned container publishing from dev to main.

- accepts immutable planned version tags
- publishes to Docker Hub and GHCR independently
- reports partial registry outcomes while preserving successful artifacts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wgtechlabs/codesmith/container-build-flow-action/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->