### PR TITLE
🔧 update (flow): support planned manual releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ All flow types use **commit SHA** (first 7 characters) for tagging, ensuring tra
 
 ### Planned main-branch releases
 
-On a push to the configured `main-branch`, set `planned-version-tag` to publish release tags without changing the event from `push`. The full value must match `release-tag-pattern`; a matching `v1.2.3` produces `1.2.3`, `1.2`, `1`, and `latest` tags (with any configured prefix or suffix). An invalid value is skipped using the same behavior as an invalid release-event tag. Omit the input to retain the normal `staging-{sha}` main-branch build.
+On a push to, or `workflow_dispatch` run from, the configured `main-branch`, set `planned-version-tag` to publish release tags. The full value must match `release-tag-pattern`; a matching `v1.2.3` produces `1.2.3`, `1.2`, `1`, and `latest` tags (with any configured prefix or suffix). An invalid value is skipped using the same behavior as an invalid release-event tag. Omit the input to retain the normal `staging-{sha}` main-branch push build or the existing manual WIP build.
 
 ```yaml
 - uses: wgtechlabs/container-build-flow-action@v1
@@ -634,7 +634,7 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 |-------|-------------|----------|---------|
 | `main-branch` | Name of main/production branch | No | `main` |
 | `dev-branch` | Name of development branch | No | `dev` |
-| `planned-version-tag` | Release tag to publish on a main-branch push; must match `release-tag-pattern` | No | `''` |
+| `planned-version-tag` | Release tag to publish on a main-branch push or manual dispatch; must match `release-tag-pattern` | No | `''` |
 
 ### Build Configuration
 

--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ See the [`examples/`](examples/) directory for complete workflow examples:
 |-------|-------------|----------|---------|
 | `main-branch` | Name of main/production branch | No | `main` |
 | `dev-branch` | Name of development branch | No | `dev` |
-| `planned-version-tag` | Release tag to publish on a main-branch push or manual dispatch; must match `release-tag-pattern` | No | `''` |
+| `planned-version-tag` | Release tag to publish on a main-branch push, or on a `workflow_dispatch` run from the main branch; ignored on other refs and must match `release-tag-pattern` | No | `''` |
 
 ### Build Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -436,7 +436,7 @@ runs:
           echo "⚠️  Skipping build — ${BOT_SKIP_REASON}"
           exit 0
         fi
-        if [ "$EVENT_NAME" = "push" ] && [ "$REF" = "refs/heads/${MAIN_BRANCH}" ] && [ -n "$PLANNED_VERSION_TAG" ]; then
+        if { [ "$EVENT_NAME" = "push" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; } && [ "$REF" = "refs/heads/${MAIN_BRANCH}" ] && [ -n "$PLANNED_VERSION_TAG" ]; then
           echo "should-build=true" >> "$GITHUB_OUTPUT"
           echo "ℹ️  Planned version tag detected on main branch — bypassing commit convention gate"
           exit 0

--- a/scripts/detect-build-flow.sh
+++ b/scripts/detect-build-flow.sh
@@ -205,8 +205,8 @@ detect_build_flow() {
             log_warning "Flow: Work in progress (non-standard PR)"
         fi
         
-    elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
-        log_info "Push event detected"
+    elif [ "$GITHUB_EVENT_NAME" = "push" ] || { [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] && [ "$GITHUB_REF" = "refs/heads/${MAIN_BRANCH}" ] && [ -n "$PLANNED_VERSION_TAG" ]; }; then
+        log_info "Push or planned manual release detected"
         
         # Extract branch name from ref
         local branch="${GITHUB_REF#refs/heads/}"

--- a/tests/test-container-build-flow.sh
+++ b/tests/test-container-build-flow.sh
@@ -23,12 +23,13 @@ run_detect() {
     local release_tag_pattern="${2:-}"
     local tag_prefix="${3-release-}"
     local tag_suffix="${4--alpine}"
+    local event_name="${5:-push}"
     local output_file
     local -a env_args
     output_file="$(mktemp)"
 
     env_args=(
-        GITHUB_EVENT_NAME=push
+        GITHUB_EVENT_NAME="$event_name"
         GITHUB_REF=refs/heads/main
         GITHUB_SHA="$SHA"
         GITHUB_REPOSITORY=example/widget
@@ -37,6 +38,7 @@ run_detect() {
         MAIN_BRANCH=main
         DEV_BRANCH=dev
         PLANNED_VERSION_TAG="$planned_tag"
+        RELEASE_TAG="$planned_tag"
         TAG_PREFIX="$tag_prefix"
         TAG_SUFFIX="$tag_suffix"
     )
@@ -128,6 +130,40 @@ assert_invalid_planned_tag_skips_main() {
 
     [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "skip" ]] ||
         fail "main pushes with an invalid planned tag must skip"
+}
+
+assert_planned_dispatch_release() {
+    local output
+    output="$(run_detect v1.2.3 "" "" "" workflow_dispatch)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "release" ]] ||
+        fail "planned tag must produce a release flow when dispatching main"
+    [[ "$(printf '%s\n' "$output" | grep '^tags=' | cut -d= -f2-)" == "1.2.3" ]] ||
+        fail "planned dispatch tag must generate its release version"
+}
+
+assert_omitted_planned_tag_keeps_dispatch_wip() {
+    local output
+    output="$(run_detect "" "" "" "" workflow_dispatch)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "wip" ]] ||
+        fail "manual main dispatches without a planned tag must remain WIP"
+}
+
+assert_invalid_planned_dispatch_skips_main() {
+    local output
+    output="$(run_detect invalid-tag "" "" "" workflow_dispatch)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "skip" ]] ||
+        fail "invalid planned tags must skip when dispatching main"
+}
+
+assert_release_event_remains_release() {
+    local output
+    output="$(run_detect v1.2.3 "" "" "" release)"
+
+    [[ "$(printf '%s\n' "$output" | grep '^build-flow-type=' | cut -d= -f2-)" == "release" ]] ||
+        fail "release events must remain release flows"
 }
 
 run_output() {
@@ -309,6 +345,14 @@ assert_push_enabled_normalization_contract() {
         fail "aggregate failure guard must use canonical push-enabled"
 }
 
+assert_planned_dispatch_bypasses_commit_gate() {
+    local commit_gate
+    commit_gate="$(action_step "Commit Convention Gate")"
+
+    [[ "$commit_gate" == *'workflow_dispatch'* ]] ||
+        fail "planned main dispatches must bypass the commit convention gate"
+}
+
 assert_planned_main_release
 assert_planned_custom_pattern_preserves_version_prefix
 assert_planned_main_prerelease
@@ -316,9 +360,14 @@ assert_planned_numeric_prerelease
 assert_planned_custom_pattern_prerelease
 assert_omitted_planned_tag_stages_main
 assert_invalid_planned_tag_skips_main
+assert_planned_dispatch_release
+assert_omitted_planned_tag_keeps_dispatch_wip
+assert_invalid_planned_dispatch_skips_main
+assert_release_event_remains_release
 assert_registry_aggregation
 assert_no_push_registry_aggregation
 assert_registry_builds_require_successful_logins_when_pushing
 assert_push_enabled_normalization_contract
+assert_planned_dispatch_bypasses_commit_gate
 
 echo "PASS: container build flow behavior"

--- a/tests/test-container-build-flow.sh
+++ b/tests/test-container-build-flow.sh
@@ -37,11 +37,17 @@ run_detect() {
         GITHUB_OUTPUT="$output_file"
         MAIN_BRANCH=main
         DEV_BRANCH=dev
-        PLANNED_VERSION_TAG="$planned_tag"
-        RELEASE_TAG="$planned_tag"
         TAG_PREFIX="$tag_prefix"
         TAG_SUFFIX="$tag_suffix"
     )
+    # Release events receive their tag through RELEASE_TAG only; every other
+    # event goes through PLANNED_VERSION_TAG. Keeping them separate prevents the
+    # tests from masking a flow that reads the wrong variable.
+    if [ "$event_name" = "release" ]; then
+        env_args+=(RELEASE_TAG="$planned_tag")
+    else
+        env_args+=(PLANNED_VERSION_TAG="$planned_tag")
+    fi
     if [ -n "$release_tag_pattern" ]; then
         env_args+=(RELEASE_TAG_PATTERN="$release_tag_pattern")
     fi


### PR DESCRIPTION
## Summary
- Generate release tags for valid planned versions on main workflow dispatches.
- Keep manual runs without a planned tag as WIP and invalid planned tags as skips.
- Document and test the manual release path while preserving release events.

## Validation
- bun run test
- bun run typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wgtechlabs/codesmith/container-build-flow-action/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->